### PR TITLE
Set sensible Bazel defaults

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,30 @@
+# It is faster to compute digests with Blake3
+startup --digest_function=blake3
+common --cache_computed_file_digests=500000
+
+# We disable sandboxing as it is slow on Darwin.
+common --noworker_sandboxing
+common --spawn_strategy=worker,local
+
+# Use a static value for `PATH` and does not inherit `LD_LIBRARY_PATH`. Doesn't let environment
+# variables like `PATH` sneak into the build, which can cause massive cache misses when they change.
+build                       --incompatible_strict_action_env
+
+# Use all available CPU cores for workers.
+build                       --worker_max_instances=HOST_CPUS
+
+# Enable local disk cache
+common --disk_cache=~/bazel_disk_cache
 common --remote_cache=grpcs://remote.buildbuddy.io
 common --noremote_upload_local_results
+# We don't want CI machines to use disk cache.
 common:upload --disk_cache=
 common:upload --remote_upload_local_results
 
 # TODO: Add auth for build buddy
+
+# No need to cache these types of artifacts
+common --modify_execution_info=^(AppleLipo|BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppArchive|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
 
 # CI
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -34,3 +34,6 @@ common:ci --config=upload
 
 common:warming --config=upload
 common:warming --remote_download_minimal
+
+# Load Xcode bazelrc file.
+xcode.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+xcode.bazelrc

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+
+# We want to make sure that Bazel always pics up the correct xcode version.
+
+bazel_real="$BAZEL_REAL"
+bazelrc_lines=()
+
+if [[ $OSTYPE == darwin* ]]; then
+  xcode_path=$(xcode-select -p)
+  xcode_version=$(xcodebuild -version | tail -1 | cut -d " " -f3)
+  xcode_build_number=$(/usr/bin/xcodebuild -version 2>/dev/null | tail -1 | cut -d " " -f3)
+
+  bazelrc_lines+=("startup --host_jvm_args=-Xdock:name=$xcode_path")
+  bazelrc_lines+=("build --xcode_version=$xcode_version")
+  bazelrc_lines+=("build --repo_env=XCODE_VERSION=$xcode_version")
+  bazelrc_lines+=("build --repo_env=DEVELOPER_DIR=$xcode_path")
+fi
+
+printf '%s\n' "${bazelrc_lines[@]}" > xcode.bazelrc
+
+exec "$bazel_real" "$@"

--- a/xcode.bazelrc
+++ b/xcode.bazelrc
@@ -1,0 +1,4 @@
+startup --host_jvm_args=-Xdock:name=/Applications/Xcode.app/Contents/Developer
+build --xcode_version=16A242d
+build --repo_env=XCODE_VERSION=16A242d
+build --repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer

--- a/xcode.bazelrc
+++ b/xcode.bazelrc
@@ -1,4 +1,0 @@
-startup --host_jvm_args=-Xdock:name=/Applications/Xcode.app/Contents/Developer
-build --xcode_version=16A242d
-build --repo_env=XCODE_VERSION=16A242d
-build --repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer


### PR DESCRIPTION
I enabled a couple of Bazel flags that have proven to be useful on larger projects.
Also made sure that we have Xcode version invalidation in place.